### PR TITLE
fix: replace bare excepts with specific types in API key caching

### DIFF
--- a/LLM_CALL.py
+++ b/LLM_CALL.py
@@ -227,7 +227,7 @@ def get_openai_token(p_token_url, p_client_id, p_client_secret, p_scope, **kwarg
             key = json.load(f)
         if time.time()<key['expire_at']:
             return key["access_token"]
-    except:
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
         pass
     
     response = requests.post(
@@ -253,7 +253,7 @@ def get_claude_token():
             key = json.load(f)
         if time.time()<key['expire_at']:
             return key["access_token"]
-    except:
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
         pass
 
     client_id = os.getenv("CLIENT_ID")


### PR DESCRIPTION
Replace bare `except:` with `except (FileNotFoundError, json.JSONDecodeError, KeyError):` in `LLM_CALL.py` (2 sites).

Both handle cached API key loading where the file may not exist, contain invalid JSON, or lack expected keys. The specific exception types cover all expected failure modes while allowing system exceptions (`KeyboardInterrupt`, `SystemExit`) to propagate.

**Changes:** `LLM_CALL.py` lines 230, 256