### PR TITLE
fix: pin liteLLM <=1.82.6 to mitigate TeamPCP supply chain attack

### DIFF
--- a/evaluation/tau2-bench/pyproject.toml
+++ b/evaluation/tau2-bench/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "psutil>=7.0.0",
     "loguru>=0.7.3",
     "docstring-parser>=0.16",
-    "litellm>=1.65.0",
+    "litellm>=1.65.0, <=1.82.6",
     "tenacity>=9.0.0",
     "matplotlib>=3.10.1",
     "seaborn>=0.13.2",

--- a/training/rollout/pyproject.toml
+++ b/training/rollout/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "psutil>=7.0.0",
     "loguru>=0.7.3",
     "docstring-parser>=0.16",
-    "litellm>=1.65.0",
+    "litellm>=1.65.0, <=1.82.6",
     "tenacity>=9.0.0",
     "matplotlib>=3.10.1",
     "seaborn>=0.13.2",


### PR DESCRIPTION
## Summary

liteLLM versions **1.82.7** and **1.82.8** were compromised by the **TeamPCP** group via a supply chain attack through Trivy. The current dependency constraint allows these malicious versions to be installed.

## Impact

The compromised versions steal sensitive credentials including SSH keys, AWS/GCP/K8s credentials, CI/CD tokens, and environment variables. Version 1.82.8 installs a `.pth` persistence mechanism that executes on every Python startup — even after liteLLM is uninstalled.

## Fix

This PR pins the upper bound of the liteLLM dependency to `<=1.82.6`, which is the last known safe version before the compromise. Once BerriAI publishes a verified clean release, this upper bound can be raised.

**Files changed (2 pyproject.toml manifests):**
- `training/rollout/pyproject.toml`: `>=1.65.0` → `>=1.65.0, <=1.82.6`
- `evaluation/tau2-bench/pyproject.toml`: `>=1.65.0` → `>=1.65.0, <=1.82.6`

**Note:** `requirements.txt` already pins `litellm==1.76.0` (safe). The `pdm.lock` files resolve to `1.65.1` (safe), but the manifests allowed unbounded upgrades.

## References

- [BerriAI/litellm#24512](https://github.com/BerriAI/litellm/issues/24512) — Incident report
- [Wiz.io Analysis](https://www.wiz.io/blog/threes-a-crowd-teampcp-trojanizes-litellm-in-continuation-of-campaign) — Attack chain analysis
- [OSV: MAL-2026-2144](https://osv.dev/vulnerability/MAL-2026-2144) — Advisory