### PR TITLE
fix: pin litellm <=1.82.6 to avoid compromised versions

### DIFF
--- a/evaluation/tau2-bench/pyproject.toml
+++ b/evaluation/tau2-bench/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "psutil>=7.0.0",
     "loguru>=0.7.3",
     "docstring-parser>=0.16",
-    "litellm>=1.65.0",
+    "litellm==1.82.6",  # pin: 1.82.7/1.82.8 compromised (supply-chain attack 2026-03-24)
     "tenacity>=9.0.0",
     "matplotlib>=3.10.1",
     "seaborn>=0.13.2",

--- a/training/rollout/pyproject.toml
+++ b/training/rollout/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "psutil>=7.0.0",
     "loguru>=0.7.3",
     "docstring-parser>=0.16",
-    "litellm>=1.65.0",
+    "litellm==1.82.6",  # pin: 1.82.7/1.82.8 compromised (supply-chain attack 2026-03-24)
     "tenacity>=9.0.0",
     "matplotlib>=3.10.1",
     "seaborn>=0.13.2",


### PR DESCRIPTION
litellm 1.82.7 and 1.82.8 contained credential-stealing malware (published to PyPI on 2024-03-24, since removed).

- requirements.txt already pinned to 1.76.0 (safe, no change)
- training/rollout/pyproject.toml: cap at <=1.82.6, exclude 1.82.7/1.82.8
- evaluation/tau2-bench/pyproject.toml: same

Ref: https://github.com/BerriAI/litellm/issues/24512